### PR TITLE
docs: separate ubuntu and debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ sudo apt install wget
 - Chrome
 
 ```sh
+# Ubuntu
 sudo apt install chromium-browser
+
+# Debian
+sudo apt install chromium
 ```
 
 #### For Windows users


### PR DESCRIPTION
Hey hey!

I'm a Debian user, so the installation instructions you provided didn't work as on Debian it's just `chromium`, there is no package named `chromium-browser`.

Have any qualms with using comments to denote the package per distribution?

In my opinion, all the commands related to a package manager should probably be put together and separated by distribution though. Happy to amend my PR if you agree, but for now I've kept the change minimal.

For example:

```sh
# Ubuntu
sudo apt-get install ffmpeg wget chromium-browser

# Debian
sudo apt-get install ffmpeg wget chromeium
```

Then it'll be much easier to manage if anyone else wants to add their distribution of choice.